### PR TITLE
Save the extracted reads in fastq.gz

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         NXF_VER:
           - "24.04.2"
-          - "latest-everything"
+          #- "latest-everything"
         profile:
           - "conda"
           - "docker"

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -38,12 +38,12 @@ process {
     }
 
     withName: KRAKENTOOLS_EXTRACTKRAKENREADS {
-        ext.args = { params.fastq_output ? "--fastq-output" : ""}
+        ext.args = { "--fastq-output"}
         ext.prefix = { "${meta.id}_${taxid.toString().replaceAll(' ', '-')}" }
         publishDir = [
             path: { "${params.outdir}/extracted_reads/kraken2" },
             mode: params.publish_dir_mode,
-            pattern: '*.{fastq.gz,fasta.gz}'
+            pattern: '*.fastq.gz'
         ]
     }
 
@@ -52,7 +52,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/extracted_reads/centrifuge" },
             mode: params.publish_dir_mode,
-            pattern: '*.fastq'
+            pattern: '*.fastq.gz'
         ]
     }
 
@@ -61,7 +61,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/extracted_reads/diamond" },
             mode: params.publish_dir_mode,
-            pattern: '*.fastq'
+            pattern: '*.fastq.gz'
         ]
     }
 

--- a/conf/test.config
+++ b/conf/test.config
@@ -30,7 +30,6 @@ params {
     // Extract reads
     perform_extract_reads         = true
     extract_kraken2_reads         = true
-    fastq_output                  = true
     extract_centrifuge_reads      = true
     extract_diamond_reads         = true
     evalue                        = 1e-20

--- a/conf/test_consensus_samtools.config
+++ b/conf/test_consensus_samtools.config
@@ -31,7 +31,6 @@ params {
     // Extract reads
     perform_extract_reads         = false
     extract_kraken2_reads         = false
-    fastq_output                  = false
     extract_centrifuge_reads      = false
     extract_diamond_reads         = false
     evalue                        = 1e-20

--- a/conf/test_denovo.config
+++ b/conf/test_denovo.config
@@ -30,7 +30,6 @@ params {
     // Extract reads
     perform_extract_reads         = true
     extract_kraken2_reads         = true
-    fastq_output                  = true
     extract_centrifuge_reads      = true
     extract_diamond_reads         = true
     evalue                        = 1e-20

--- a/conf/test_screenpathogen.config
+++ b/conf/test_screenpathogen.config
@@ -31,7 +31,6 @@ params {
     // Extract reads
     perform_extract_reads         = false
     extract_kraken2_reads         = false
-    fastq_output                  = false
     extract_centrifuge_reads      = false
     extract_diamond_reads         = false
     evalue                        = 1e-20

--- a/conf/test_taxid.config
+++ b/conf/test_taxid.config
@@ -31,7 +31,7 @@ params {
     // Extract reads
     perform_extract_reads         = true
     extract_kraken2_reads         = true
-    fastq_output                  = true
+    fastq_output                  = false
     extract_centrifuge_reads      = true
     extract_diamond_reads         = true
     evalue                        = 1e-20

--- a/conf/test_taxid.config
+++ b/conf/test_taxid.config
@@ -31,7 +31,6 @@ params {
     // Extract reads
     perform_extract_reads         = true
     extract_kraken2_reads         = true
-    fastq_output                  = false
     extract_centrifuge_reads      = true
     extract_diamond_reads         = true
     evalue                        = 1e-20

--- a/docs/output.md
+++ b/docs/output.md
@@ -63,11 +63,11 @@ Retrieve the reads of all viral TaxIDs predicted by classifiers or extracts read
 
 - `extracted_reads/`
   - `centrifuge/`
-    - `<sample_id>_<taxID>.extracted_centrifuge.fastq` : Reads assigned to certain TaxID by `Centrifuge`.
+    - `<sample_id>_<taxID>.extracted_centrifuge.fastq.gz` : Reads assigned to certain TaxID by `Centrifuge`.
   - `diamond/`
-    - `<sample_id>_<taxID>.extracted_diamond.fastq` : Reads assigned to certain TaxID by `DIAMOND`.
+    - `<sample_id>_<taxID>.extracted_diamond.fastq.gz` : Reads assigned to certain TaxID by `DIAMOND`.
   - `kraken2/`
-    - `<sample_id>_<taxID>.extracted_kraken2.fastq` : Reads assigned to certain TaxID by `Kraken2`.
+    - `<sample_id>_<taxID>.extracted_kraken2.fastq.gz` : Reads assigned to certain TaxID by `Kraken2`.
 
 </details>
 

--- a/modules/local/extractcentrifugereads/environment.yml
+++ b/modules/local/extractcentrifugereads/environment.yml
@@ -1,8 +1,7 @@
-name: extractdiamondreads
+name: extractcentrifugereads
 channels:
   - conda-forge
   - bioconda
 dependencies:
   - bioconda::seqkit=2.9.0
-  - conda-forge::python=3.13.1
   - conda-forge::pigz=2.8

--- a/modules/local/extractcentrifugereads/main.nf
+++ b/modules/local/extractcentrifugereads/main.nf
@@ -25,14 +25,19 @@ process EXTRACTCENTRIFUGEREADS {
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
     awk -v taxID=$taxid '\$3 == taxID && \$8 == 1 {print \$1}' $results > readID.txt
-    if [ "${meta.single_end}" == 'true' ]; then
-        seqkit grep -f readID.txt $fastq | pigz -c > ${prefix}_${taxid}.extracted_centrifuge_read.fastq.gz
-    elif [ "${meta.single_end}" == 'false' ]; then
-        seqkit grep -f readID.txt ${fastq[0]} | pigz -c > ${prefix}_${taxid}.extracted_centrifuge_read1.fastq.gz
-        seqkit grep -f readID.txt ${fastq[1]} | pigz -c > ${prefix}_${taxid}.extracted_centrifuge_read2.fastq.gz
+
+    if [ -s readID.txt ]; then
+        if [ "${meta.single_end}" == 'true' ]; then
+            seqkit grep -f readID.txt $fastq | pigz -c > ${prefix}_${taxid}.extracted_centrifuge_read.fastq.gz
+        else
+            seqkit grep -f readID.txt ${fastq[0]} | pigz -c > ${prefix}_${taxid}.extracted_centrifuge_read1.fastq.gz
+            seqkit grep -f readID.txt ${fastq[1]} | pigz -c > ${prefix}_${taxid}.extracted_centrifuge_read2.fastq.gz
+        fi
+    else
+        echo "No matching read IDs found for taxid ${taxid}, skipping extraction."
     fi
 
-    rm readID.txt
+    rm -f readID.txt
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/extractcentrifugereads/main.nf
+++ b/modules/local/extractcentrifugereads/main.nf
@@ -3,10 +3,10 @@ process EXTRACTCENTRIFUGEREADS {
     tag "$meta.id"
     label 'process_low'
 
-    conda "bioconda::seqkit=2.8.2"
+    conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/seqkit:2.8.2--h9ee0642_1':
-        'biocontainers/seqkit:2.8.2--h9ee0642_1' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/35/356ece0aff45ac01c9369c47079609dcbd924d06597a2326804078676300b80b/data':
+        'community.wave.seqera.io/library/seqkit_pigz:30386cbe834c3ae7' }"
 
     input:
     val taxid
@@ -14,8 +14,8 @@ process EXTRACTCENTRIFUGEREADS {
     tuple val (meta), path(fastq) // bowtie2/align *unmapped_{1,2}.fastq.gz
 
     output:
-    tuple val(meta), path("*.fastq"), optional:true, emit: extracted_centrifuge_reads
-    path "versions.yml"                            , emit: versions
+    tuple val(meta), path("*.fastq.gz"), optional:true, emit: extracted_centrifuge_reads
+    path "versions.yml"                               , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -26,10 +26,10 @@ process EXTRACTCENTRIFUGEREADS {
     """
     awk -v taxID=$taxid '\$3 == taxID && \$8 == 1 {print \$1}' $results > readID.txt
     if [ "${meta.single_end}" == 'true' ]; then
-        seqkit grep -f readID.txt $fastq > ${prefix}_${taxid}.extracted_centrifuge_read.fastq
+        seqkit grep -f readID.txt $fastq | pigz -c > ${prefix}_${taxid}.extracted_centrifuge_read.fastq.gz
     elif [ "${meta.single_end}" == 'false' ]; then
-        seqkit grep -f readID.txt ${fastq[0]} > ${prefix}_${taxid}.extracted_centrifuge_read1.fastq
-        seqkit grep -f readID.txt ${fastq[1]} > ${prefix}_${taxid}.extracted_centrifuge_read2.fastq
+        seqkit grep -f readID.txt ${fastq[0]} | pigz -c > ${prefix}_${taxid}.extracted_centrifuge_read1.fastq.gz
+        seqkit grep -f readID.txt ${fastq[1]} | pigz -c > ${prefix}_${taxid}.extracted_centrifuge_read2.fastq.gz
     fi
 
     rm readID.txt
@@ -37,6 +37,7 @@ process EXTRACTCENTRIFUGEREADS {
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         seqkit: \$( seqkit version | sed 's/seqkit v//' )
+        pigz: \$(pigz --version 2>&1 | sed -e 's/pigz //g')
     END_VERSIONS
     """
 }

--- a/modules/local/extractcentrifugereads/meta.yml
+++ b/modules/local/extractcentrifugereads/meta.yml
@@ -32,7 +32,7 @@ output:
   - - extracted_centrifuge_reads:
         type: file
         description: FastQ files contain the extracted reads of a specified taxid
-        pattern: "*fastq"
+        pattern: "*fastq.gz"
   - versions:
       type: file
       description: File containing software versions

--- a/modules/local/extractdiamondreads/main.nf
+++ b/modules/local/extractdiamondreads/main.nf
@@ -5,8 +5,8 @@ process EXTRACTCDIAMONDREADS {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/11/1195d7edbe47145bda13bf6809891dc2fbe9df749c2e567b8879518b8de4ca33/data':
-        'community.wave.seqera.io/library/seqkit_python:cf97bbadc3675f5b' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/eb/ebc86c3786bdc70fe31e9fac77ab4d05af3d27664a259298a831d1994fcb022d/data':
+        'community.wave.seqera.io/library/seqkit_pigz_python:3ff8d721e22b2875' }"
 
     input:
     val taxid
@@ -15,8 +15,8 @@ process EXTRACTCDIAMONDREADS {
     tuple val (meta), path(fastq)
 
     output:
-    tuple val(meta), path("*.fastq"), optional: true, emit: extracted_diamond_reads
-    path "versions.yml"                             , emit: versions
+    tuple val(meta), path("*.fastq.gz"), optional: true, emit: extracted_diamond_reads
+    path "versions.yml"                                , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -32,12 +32,16 @@ process EXTRACTCDIAMONDREADS {
         --evalue $evalue \\
         --prefix $prefix \\
         $single_end_flag \\
-        --fastq ${fastq.join(' ')}
+        --fastq ${fastq.join(' ')} # joins the list of file paths into a space-separated string
+
+    # Compress the resulting fastq files
+    pigz -p $task.cpus *.fastq
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         seqkit: \$( seqkit version | sed -e 's/seqkit v//g' )
         python: \$( python --version | sed -e 's/Python //g')
+        pigz: \$(pigz --version 2>&1 | sed -e 's/pigz //g')
     END_VERSIONS
     """
 }

--- a/modules/local/extractdiamondreads/meta.yml
+++ b/modules/local/extractdiamondreads/meta.yml
@@ -30,7 +30,7 @@ output:
   - extracted_diamond_reads:
       type: file
       description: FastQ files contain the extracted reads of a specified taxid
-      pattern: "*fastq"
+      pattern: "*fastq.gz"
   - versions:
       type: file
       description: File containing software versions

--- a/modules/local/rm_empty_fastq/main.nf
+++ b/modules/local/rm_empty_fastq/main.nf
@@ -8,20 +8,24 @@ process RM_EMPTY_FASTQ {
     output:
     path folder, optional: true
 
+    // Consider refactoring this to use conditional logic in the workflow
     when:
     task.ext.when == null || task.ext.when
 
     script:
-    def args = task.ext.args ?: ''
     """
-    if [ -d ${folder} ]; then
-        for f in ${folder}/*; do
-            if [ ! -s \$f ]; then
-                rm \$f
+    if [ -d "${folder}" ]; then
+        for f in "${folder}"/*.fastq.gz; do
+            if [ -f "\$f" ]; then
+                if [ \$(gzip -dc "\$f" | wc -c) -eq 0 ]; then
+                    echo "Removing empty compressed file: \$f"
+                    rm "\$f"
+                fi
             fi
         done
     else
         echo "Folder ${folder} doesn't exist."
+        exit 1
     fi
     """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -52,7 +52,6 @@ params {
     // Extract kraken2 reads
     perform_extract_reads               = false
     extract_kraken2_reads               = false
-    fastq_output                        = false
     extract_centrifuge_reads            = false
     extract_diamond_reads               = false
     evalue                              = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -63,11 +63,6 @@
                     "description": "Extract reads classified by diamond according to taxonomic ID.",
                     "fa_icon": "fas fa-toggle-on"
                 },
-                "fastq_output": {
-                    "type": "boolean",
-                    "description": "Turn on saving extracted kraken2 reads in FASTQ format.",
-                    "fa_icon": "fas fa-file-alt"
-                },
                 "evalue": {
                     "type": ["number", "integer"],
                     "description": "A Expected value to report an alignment.",

--- a/workflows/metaval.nf
+++ b/workflows/metaval.nf
@@ -96,11 +96,10 @@ workflow METAVAL {
         // Filter out empty FASTQ files
         ch_taxid_reads_result = TAXID_READS.out.reads
             .branch {
-                non_empty: it[0].single_end ? it[1].size() > 0 : it[1][0].size() > 0 || it[1][1].size() >0
+                non_empty: it[0].single_end ? it[1].size() > 20 : it[1][0].size() > 20 || it[1][1].size() >20 // The size of the empty fastq.gz is 20
                 empty: true
             }
         ch_taxid_reads_result.non_empty.set { ch_taxid_reads }
-
         // Skip the de-novo assembly if the number of reads is lower than params.min_read_counts
         ch_taxid_reads
             .branch {


### PR DESCRIPTION
- Make sure the extracted reads of taxid from `Kraken2`, `Centrifuge` and `DIAMOND` are compressed FASTQ file `fastq.gz`
- Remove the params.fastq_output and define `--fastq-output` in `modules.config` instead. 

<!--
# genomic-medicine-sweden/metaval pull request

Many thanks for contributing to genomic-medicine-sweden/metaval!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/genomic-medicine-sweden/metaval/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/genomic-medicine-sweden/metaval/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
